### PR TITLE
Change link to hexagonal architecture article

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ PHPdoc is intended for documenting your code. The intention is that you always a
 ## Hexagonal Architecture
 
 * [Ports & Adapters Architecture](https://herbertograca.com/2017/09/14/ports-adapters-architecture/)
-* [Hexagonal Architecture demystified](https://madewithlove.be/hexagonal-architecture-demystified/)
+* [Hexagonal Architecture demystified](https://madewithlove.com/blog/software-engineering/hexagonal-architecture-demystified/)
 * [Hexagonal Architecture](https://fideloper.com/hexagonal-architecture)
 * [Alistair in the "Hexagone"](https://www.youtube.com/watch?v=th4AgBcrEHA)
 * [Object Design Style Guide](https://www.manning.com/books/object-design-style-guide)


### PR DESCRIPTION
### Fixed

- Link to the article directly (we have a new domain)